### PR TITLE
CSV Imbalance Data

### DIFF
--- a/rte_api/__init__.py
+++ b/rte_api/__init__.py
@@ -1,3 +1,4 @@
 from .balancing_energy import BalancingEnergyAPI
 from .big_adjusted import BigAdjustedAPI
 from .wholesale_market import WholesaleMarketAPI
+from .common import ContentType

--- a/rte_api/common/__init__.py
+++ b/rte_api/common/__init__.py
@@ -1,1 +1,2 @@
 from .RTE import RTEAPI
+from .headers import ContentType

--- a/rte_api/common/headers/HTTP.py
+++ b/rte_api/common/headers/HTTP.py
@@ -1,0 +1,5 @@
+from enum import StrEnum
+
+class ContentType(StrEnum):
+    JSON = "application/json"
+    CSV = "text/csv"

--- a/rte_api/common/headers/__init__.py
+++ b/rte_api/common/headers/__init__.py
@@ -1,0 +1,1 @@
+from .HTTP import ContentType


### PR DESCRIPTION
RTE limits requests for imbalance data to one month when requesting the data in JSON format and 1 year when requesting the data in CSV. This PR Adds support for CSV downloads of imbalance data.